### PR TITLE
snap: update to core22, minor reformatting, version bump

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,19 +1,19 @@
-name: term2048 # you probably want to 'snapcraft register <name>'
-version: '0.2.5' # just for humans, typically '1.2+git' or '1.3.2'
+name: term2048
+version: '0.2.6'
 summary: 2048 in your terminal
 description: |
-        term2048 is a terminal-based version of 2048.
-        Just like 2048, but in the terminal!
-grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: strict # use 'strict' once you have the right plugs and slots
+  term2048 is a terminal-based version of 2048.
+  Just like 2048, but in the terminal!
+grade: stable
+confinement: strict
+base: core22
 
 apps:
-        term2048:
-                command: bin/term2048
+  term2048:
+    command: bin/term2048
 
 parts:
   term2048:
-    # See 'snapcraft plugins'
     source: https://github.com/bfontaine/term2048.git
-    source-tag: 0.2.5
+    source-tag: 0.2.6
     plugin: python


### PR DESCRIPTION
This snap hasn't been building for a while.  I updated to `core22`, bumped the source version, and did a bit of reformatting.

Note this game is has a blank-screen bug on Linux (see upstream issue https://github.com/bfontaine/term2048/issues/34).